### PR TITLE
feat: use callback function for Lsig verification params

### DIFF
--- a/__test__/verifier.test.ts
+++ b/__test__/verifier.test.ts
@@ -254,7 +254,6 @@ describe("verifier", () => {
 describe("verifier lsig", () => {
   let verifier: LsigVerifier;
   let algorand: AlgorandClient;
-  const lsigsNeededForBudget = 6;
   let client: SignalsAndProofClient;
 
   beforeAll(async () => {
@@ -263,7 +262,6 @@ describe("verifier lsig", () => {
       algorand,
       "circuit/circuit_final.zkey",
       "circuit/circuit_js/circuit.wasm",
-      lsigsNeededForBudget,
     );
 
     const signalsAndProofFactory = new SignalsAndProofFactory({
@@ -281,28 +279,27 @@ describe("verifier lsig", () => {
   it("works", async () => {
     const group = client.newGroup();
 
-    const params = await verifier.verificationParams({ a: 10, b: 21 });
+    await verifier.verificationParams({
+      inputs: { a: 10, b: 21 },
+      composer: group,
+      paramsCallback: async (params) => {
+        const { appParams, lsigsFee } = params;
 
-    const { appParams, extraLsigsTxns, lsigFees } = params;
+        // Call app with signals and proof via lsig
+        group.signalsAndProof(appParams);
 
-    // Call app with signals and proof via lsig
-    group.signalsAndProof(appParams);
-
-    // Add extra lsig txns to get opcode budget
-    for (const txn of extraLsigsTxns) {
-      group.addTransaction(txn);
-    }
-
-    // Pay the required fees
-    const feePayer = await algorand.account.localNetDispenser();
-    group.addTransaction(
-      await algorand.createTransaction.payment({
-        sender: feePayer,
-        amount: microAlgos(0),
-        receiver: feePayer,
-        extraFee: lsigFees,
-      }),
-    );
+        // Pay the required fees
+        const feePayer = await algorand.account.localNetDispenser();
+        group.addTransaction(
+          await algorand.createTransaction.payment({
+            sender: feePayer,
+            amount: microAlgos(0),
+            receiver: feePayer,
+            extraFee: lsigsFee,
+          }),
+        );
+      },
+    });
 
     await group.send();
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snarkjs-algorand",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "type": "module",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,10 @@ import {
   type Arc56Contract,
 } from "@algorandfoundation/algokit-utils/types/app-arc56";
 import { readFileSync } from "fs";
-import type { RawSimulateOptions } from "@algorandfoundation/algokit-utils/types/composer";
+import type {
+  RawSimulateOptions,
+  TransactionComposer,
+} from "@algorandfoundation/algokit-utils/types/composer";
 import type { Transaction } from "algosdk";
 import type { AppClientMethodCallParams } from "@algorandfoundation/algokit-utils/types/app-client";
 import algosdk, { OnApplicationComplete, type Address } from "algosdk";
@@ -199,7 +202,7 @@ export class LsigVerifier {
     public algorand: AlgorandClient,
     public zKey: snarkjs.ZKArtifact,
     public wasmProver: snarkjs.ZKArtifact,
-    public totalLsigs: number,
+    public totalLsigs: number = 6,
   ) {}
 
   private async ensureCurveInstanttiation() {
@@ -263,15 +266,27 @@ export class LsigVerifier {
     return this.algorand.account.logicsig(compilation.compiledBase64ToBytes);
   }
 
-  async verificationParams(inputs: snarkjs.CircuitSignals): Promise<{
-    appParams: {
-      sender: Address;
-      staticFee: AlgoAmount;
-      args: { signals: bigint[]; proof: Proof; lw: LagrangeWitness };
+  async verificationParams({
+    inputs,
+    composer,
+    paramsCallback,
+    addExtraLsigs = true,
+  }: {
+    inputs: snarkjs.CircuitSignals;
+    composer: {
+      addTransaction: (txn: Transaction) => unknown;
     };
-    lsigFees: AlgoAmount;
-    extraLsigsTxns: Transaction[];
-  }> {
+    addExtraLsigs?: boolean;
+    paramsCallback: (params: {
+      appParams: {
+        sender: Address;
+        staticFee: AlgoAmount;
+        args: { signals: bigint[]; proof: Proof; lw: LagrangeWitness };
+      };
+      lsigsFee: AlgoAmount;
+      extraLsigsTxns: Transaction[];
+    }) => Promise<void>;
+  }): Promise<void> {
     const { proof, signals, lw } = await this.proofAndSignals(inputs);
 
     const params = {
@@ -280,7 +295,7 @@ export class LsigVerifier {
         staticFee: microAlgos(0),
         args: { signals, proof, lw },
       },
-      lsigFees: microAlgos(1000 * this.totalLsigs),
+      lsigsFee: microAlgos(1000 * this.totalLsigs),
       extraLsigsTxns: [] as Transaction[],
     };
 
@@ -290,6 +305,8 @@ export class LsigVerifier {
     const extraLsig = this.algorand.account.logicsig(
       compilation.compiledBase64ToBytes,
     );
+
+    await paramsCallback(params);
 
     for (let i = 0; i < this.totalLsigs - 1; i++) {
       const lsigPay = await this.algorand.createTransaction.payment({
@@ -301,9 +318,11 @@ export class LsigVerifier {
       });
 
       params.extraLsigsTxns.push(lsigPay);
-    }
 
-    return params;
+      if (addExtraLsigs) {
+        composer.addTransaction(lsigPay);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
With the optimizations for lagrange evaluations we can now assume most circuits will require 6 lsig txns for budget. This means we can do the extra lsig txn adding automatically if the caller supplies the composer