### PR TITLE
fix: use explicit sender/signer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# UNRELEASED 0.11.1
+# UNRELEASED 0.12.0
+
+## BREAKING CHANGES
+
+- `extraLsigsTxns` in `paramsCallback` has changed from `Transaction[]` to `TransactionWithSigner[]`
 
 ## Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# UNRELEASED 0.11.1
+
+## Fixes
+
+- Use explicit sender address and signer for lsigs in verification group
+
+## Notes
+
+- This release also includes some significant refactors to the verifiers. Please report any new bugs
+
 # 0.11.0
 
 ## BREAKING CHANGES

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/src/common.ts
+++ b/src/common.ts
@@ -499,7 +499,7 @@ export abstract class LsigVerifier<
         note: `Extra lsig ${i + 1} of ${this.totalLsigs - 1}`,
       });
 
-      params.extraLsigsTxns.push({ txn: lsigPay, signer: lsigAccount.signer });
+      params.extraLsigsTxns.push({ txn: lsigPay, signer: extraLsig.signer });
 
       if (args.addExtraLsigs ?? true) {
         args.composer.addTransaction(lsigPay, extraLsig.signer);

--- a/src/common.ts
+++ b/src/common.ts
@@ -462,9 +462,12 @@ export abstract class LsigVerifier<
       signals = args.signals;
     }
 
+    const lsigAccount = await this.lsigAccount();
+
     const params = {
       lsigParams: {
-        sender: await this.lsigAccount(),
+        sender: lsigAccount.addr,
+        signer: lsigAccount.signer,
         staticFee: microAlgos(0),
       },
       args: { signals: signals, proof: proof },
@@ -483,7 +486,8 @@ export abstract class LsigVerifier<
 
     for (let i = 0; i < this.totalLsigs - 1; i++) {
       const lsigPay = await this.algorand.createTransaction.payment({
-        sender: extraLsig,
+        sender: extraLsig.addr,
+        signer: extraLsig.signer,
         amount: microAlgos(0),
         staticFee: microAlgos(0),
         receiver: extraLsig,

--- a/src/common.ts
+++ b/src/common.ts
@@ -326,6 +326,7 @@ export type LsigVerificationArgs<Witness extends Record<string, any>> = {
   paramsCallback: (params: {
     lsigParams: {
       sender: Address;
+      signer: TransactionSigner;
       staticFee: AlgoAmount;
     };
     args: { signals: Witness["signals"]; proof: Witness["proof"] };

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,5 +1,10 @@
 import type { AlgorandClient } from "@algorandfoundation/algokit-utils";
-import type { Address, Transaction } from "algosdk";
+import type {
+  Address,
+  Transaction,
+  TransactionSigner,
+  TransactionWithSigner,
+} from "algosdk";
 import type {
   Groth16Bls12381VerifierFactory,
   Groth16Bls12381VerificationKey,
@@ -315,7 +320,7 @@ export type LsigVerifierOptions<VerificationKey> =
 
 export type LsigVerificationArgs<Witness extends Record<string, any>> = {
   composer: {
-    addTransaction: (txn: Transaction) => unknown;
+    addTransaction: (txn: Transaction, signer?: TransactionSigner) => unknown;
   };
   addExtraLsigs?: boolean;
   paramsCallback: (params: {
@@ -325,7 +330,7 @@ export type LsigVerificationArgs<Witness extends Record<string, any>> = {
     };
     args: { signals: Witness["signals"]; proof: Witness["proof"] };
     lsigsFee: AlgoAmount;
-    extraLsigsTxns: Transaction[];
+    extraLsigsTxns: TransactionWithSigner[];
   }) => Promise<void>;
 } & (
   | { inputs: snarkjs.CircuitSignals }
@@ -472,7 +477,7 @@ export abstract class LsigVerifier<
       },
       args: { signals: signals, proof: proof },
       lsigsFee: microAlgos(1000 * this.totalLsigs),
-      extraLsigsTxns: [] as Transaction[],
+      extraLsigsTxns: [] as TransactionWithSigner[],
     };
 
     const compilation = await this.algorand.app.compileTeal(
@@ -487,17 +492,16 @@ export abstract class LsigVerifier<
     for (let i = 0; i < this.totalLsigs - 1; i++) {
       const lsigPay = await this.algorand.createTransaction.payment({
         sender: extraLsig.addr,
-        signer: extraLsig.signer,
         amount: microAlgos(0),
         staticFee: microAlgos(0),
         receiver: extraLsig,
         note: `Extra lsig ${i + 1} of ${this.totalLsigs - 1}`,
       });
 
-      params.extraLsigsTxns.push(lsigPay);
+      params.extraLsigsTxns.push({ txn: lsigPay, signer: lsigAccount.signer });
 
       if (args.addExtraLsigs ?? true) {
-        args.composer.addTransaction(lsigPay);
+        args.composer.addTransaction(lsigPay, extraLsig.signer);
       }
     }
   }


### PR DESCRIPTION
I keep running into weird bugs with sender/signers in groups. I'm not 100% sure this will fix it, but might help debugging at the very least